### PR TITLE
Support release and development versions of java/cpp docs

### DIFF
--- a/files/caddy/Caddyfile
+++ b/files/caddy/Caddyfile
@@ -10,7 +10,13 @@ javadocs.photonvision.org {
 
 	redir @root /release
 
-	redir /org/{uri} /release/org/{uri}
+	@notReleaseOrDev {
+		not path /release/* /development/*
+	}
+
+	handle @notReleaseOrDev {
+		redir /release{uri}
+	}
 
 	# Serve /release and /development from local directories
 	handle_path /release* {
@@ -31,6 +37,14 @@ cppdocs.photonvision.org {
 	}
 
 	redir @root /release
+
+	@notReleaseOrDev {
+		not path /release/* /development/*
+	}
+
+	handle @notReleaseOrDev {
+		redir /release{uri}
+	}
 
 	# Serve /release and /development from local directories
 	handle_path /release* {

--- a/files/caddy/Caddyfile
+++ b/files/caddy/Caddyfile
@@ -11,12 +11,12 @@ javadocs.photonvision.org {
 
 	# Serve /stable and /latest from local directories
 	handle_path /stable* {
-		root * /var/www/html/photonvision-docs/stable/built-docs/javadoc/html
+		root * /var/www/html/photonvision-docs/stable/built-docs/javadoc
 		file_server
 	}
 
 	handle_path /latest* {
-		root * /var/www/html/photonvision-docs/latest/built-docs/javadoc/html
+		root * /var/www/html/photonvision-docs/latest/built-docs/javadoc
 		file_server
 	}
 }

--- a/files/caddy/Caddyfile
+++ b/files/caddy/Caddyfile
@@ -4,18 +4,40 @@ photonvision.org {
 }
 
 javadocs.photonvision.org {
-    root * /var/www/html/photonvision-docs/built-docs/javadoc
-    file_server
-}
+    @root {
+		path /
+	}
+	redirect @root /stable
 
-apidocs.photonvision.org {
-    root * /var/www/html/photonvision-docs-landing
-    file_server
+	# Serve /stable and /latest from local directories
+	handle_path /stable* {
+		root * /var/www/html/photonvision-docs/stable/built-docs/javadoc/html
+		file_server
+	}
+
+	handle_path /latest* {
+		root * /var/www/html/photonvision-docs/latest/built-docs/javadoc/html
+		file_server
+	}
 }
 
 cppdocs.photonvision.org {
-    root * /var/www/html/photonvision-docs/built-docs/doxygen/html
-    file_server
+
+    @root {
+		path /
+	}
+	redirect @root /stable
+
+	# Serve /stable and /latest from local directories
+	handle_path /stable* {
+		root * /var/www/html/photonvision-docs/stable/built-docs/doxygen/html
+		file_server
+	}
+
+	handle_path /latest* {
+		root * /var/www/html/photonvision-docs/latest/built-docs/doxygen/html
+		file_server
+	}
 }
 
 demo.photonvision.org {

--- a/files/caddy/Caddyfile
+++ b/files/caddy/Caddyfile
@@ -4,58 +4,57 @@ photonvision.org {
 }
 
 javadocs.photonvision.org {
-    	@root {
-		path /
-	}
+    @root {
+        path /
+    }
 
-	redir @root /release
+    redir @root /release
 
-	@notReleaseOrDev {
-		not path /release/* /development/*
-	}
+    @notReleaseOrDev {
+        not path /release/* /development/*
+    }
 
-	handle @notReleaseOrDev {
-		redir /release{uri}
-	}
+    handle @notReleaseOrDev {
+        redir /release{uri}
+    }
 
-	# Serve /release and /development from local directories
-	handle_path /release* {
-		root * /var/www/html/photonvision-docs/release/built-docs/javadoc
-		file_server
-	}
+    # Serve /release and /development from local directories
+    handle_path /release* {
+        root * /var/www/html/photonvision-docs/release/built-docs/javadoc
+        file_server
+    }
 
-	handle_path /development* {
-		root * /var/www/html/photonvision-docs/development/built-docs/javadoc
-		file_server
-	}
+    handle_path /development* {
+        root * /var/www/html/photonvision-docs/development/built-docs/javadoc
+        file_server
+    }
 }
 
 cppdocs.photonvision.org {
+    @root {
+        path /
+    }
 
-    	@root {
-		path /
-	}
+    redir @root /release
 
-	redir @root /release
+    @notReleaseOrDev {
+        not path /release/* /development/*
+    }
 
-	@notReleaseOrDev {
-		not path /release/* /development/*
-	}
+    handle @notReleaseOrDev {
+        redir /release{uri}
+    }
 
-	handle @notReleaseOrDev {
-		redir /release{uri}
-	}
+    # Serve /release and /development from local directories
+    handle_path /release* {
+        root * /var/www/html/photonvision-docs/release/built-docs/doxygen/html
+        file_server
+    }
 
-	# Serve /release and /development from local directories
-	handle_path /release* {
-		root * /var/www/html/photonvision-docs/release/built-docs/doxygen/html
-		file_server
-	}
-
-	handle_path /development* {
-		root * /var/www/html/photonvision-docs/development/built-docs/doxygen/html
-		file_server
-	}
+    handle_path /development* {
+        root * /var/www/html/photonvision-docs/development/built-docs/doxygen/html
+        file_server
+    }
 }
 
 demo.photonvision.org {

--- a/files/caddy/Caddyfile
+++ b/files/caddy/Caddyfile
@@ -7,16 +7,16 @@ javadocs.photonvision.org {
     @root {
 		path /
 	}
-	redirect @root /stable
+	redirect @root /release
 
-	# Serve /stable and /latest from local directories
-	handle_path /stable* {
-		root * /var/www/html/photonvision-docs/stable/built-docs/javadoc
+	# Serve /release and /development from local directories
+	handle_path /release* {
+		root * /var/www/html/photonvision-docs/release/built-docs/javadoc
 		file_server
 	}
 
-	handle_path /latest* {
-		root * /var/www/html/photonvision-docs/latest/built-docs/javadoc
+	handle_path /development* {
+		root * /var/www/html/photonvision-docs/development/built-docs/javadoc
 		file_server
 	}
 }
@@ -26,16 +26,16 @@ cppdocs.photonvision.org {
     @root {
 		path /
 	}
-	redirect @root /stable
+	redirect @root /release
 
-	# Serve /stable and /latest from local directories
-	handle_path /stable* {
-		root * /var/www/html/photonvision-docs/stable/built-docs/doxygen/html
+	# Serve /release and /development from local directories
+	handle_path /release* {
+		root * /var/www/html/photonvision-docs/release/built-docs/doxygen/html
 		file_server
 	}
 
-	handle_path /latest* {
-		root * /var/www/html/photonvision-docs/latest/built-docs/doxygen/html
+	handle_path /development* {
+		root * /var/www/html/photonvision-docs/development/built-docs/doxygen/html
 		file_server
 	}
 }

--- a/files/caddy/Caddyfile
+++ b/files/caddy/Caddyfile
@@ -4,10 +4,13 @@ photonvision.org {
 }
 
 javadocs.photonvision.org {
-    @root {
+    	@root {
 		path /
 	}
+
 	redir @root /release
+
+	redir /org/{uri} /release/org/{uri}
 
 	# Serve /release and /development from local directories
 	handle_path /release* {
@@ -23,9 +26,10 @@ javadocs.photonvision.org {
 
 cppdocs.photonvision.org {
 
-    @root {
+    	@root {
 		path /
 	}
+
 	redir @root /release
 
 	# Serve /release and /development from local directories

--- a/files/caddy/Caddyfile
+++ b/files/caddy/Caddyfile
@@ -7,7 +7,7 @@ javadocs.photonvision.org {
     @root {
 		path /
 	}
-	redirect @root /release
+	redir @root /release
 
 	# Serve /release and /development from local directories
 	handle_path /release* {
@@ -26,7 +26,7 @@ cppdocs.photonvision.org {
     @root {
 		path /
 	}
-	redirect @root /release
+	redir @root /release
 
 	# Serve /release and /development from local directories
 	handle_path /release* {


### PR DESCRIPTION
Update java and cpp docs pages to redirect to the release version automatically, and serve release and development verions.

Also remove apidocs.photonvision.org as unused.